### PR TITLE
Fix config name overlapping

### DIFF
--- a/alerts/add-runbook-links.libsonnet
+++ b/alerts/add-runbook-links.libsonnet
@@ -10,13 +10,13 @@ local lower(x) =
 
 {
   _config+:: {
-    runbookURLPattern: 'https://github.com/povilasv/coredns-mixin/tree/master/runbook.md#alert-name-%s',
+    corednsRunbookURLPattern: 'https://github.com/povilasv/coredns-mixin/tree/master/runbook.md#alert-name-%s',
   },
 
   prometheusAlerts+::
     local addRunbookURL(rule, group) = rule {
       [if 'alert' in rule && std.member(['coredns', 'coredns_forward'], group.name) then 'annotations']+: {
-        runbook_url: $._config.runbookURLPattern % lower(rule.alert),
+        runbook_url: $._config.corednsRunbookURLPattern % lower(rule.alert),
       },
     };
     utils.mapRuleGroups(addRunbookURL),


### PR DESCRIPTION
This PR fixes #2 by preventing the overwriting of runbook_url defined in [kubernetes-mixin](https://github.com/povilasv/coredns-mixin/blob/master/alerts/add-runbook-links.libsonnet#L13).
More details in the [issue comment](https://github.com/povilasv/coredns-mixin/issues/2#issuecomment-640126385)