### PR TITLE
Fix for failing mixin import in kube-prometheus

### DIFF
--- a/config.libsonnet
+++ b/config.libsonnet
@@ -3,13 +3,13 @@
     corednsSelector: 'job="kube-dns"',
     instanceLabel: 'pod',
 
-    grafanaDashboardIDs: {
+    grafanaDashboardIDs+: {
       'coredns.json': 'thael1rie7ohG6OY3eMeisahtee2iGoo1gooGhuu',
     },
 
     pluginNameLabel: 'name',
     kubernetesPlugin: false,
-    grafana: {
+    grafana+: {
       dashboardNamePrefix: '',
       dashboardTags: ['coredns-mixin'],
 


### PR DESCRIPTION
When we try to import the coredns-mixin into kube-prometheus, it fails with the following error,
`
RUNTIME ERROR: Field does not exist: ldap
vendor/grafana/grafana.libsonnet:50:32-54	thunk <grafanaConfig> from <object <anonymous>>
vendor/grafana/grafana.libsonnet:51:36-49	thunk from <object <anonymous>>
vendor/ksonnet/ksonnet.beta.4/k8s.libsonnet:9656:82-86
vendor/ksonnet/ksonnet.beta.4/k8s.libsonnet:9658:41-45	object <anonymous>
During manifestation
`

The issue is basically in config.libsonnet. 
The fields grafanaDashboardIDs & grafana should be merged with the kube-prometheus and not override them.