### PR TITLE
dashboards: use full name of the dependency

### DIFF
--- a/dashboards/coredns.libsonnet
+++ b/dashboards/coredns.libsonnet
@@ -1,4 +1,4 @@
-local grafana = import 'grafonnet/grafana.libsonnet';
+local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
 local dashboard = grafana.dashboard;
 local row = grafana.row;
 local prometheus = grafana.prometheus;


### PR DESCRIPTION
This allows to work with latest `jb` and not use legacy imports.