### PR TITLE
Datasource template variable should be labelled 'Data Source'

### DIFF
--- a/dashboards/coredns.libsonnet
+++ b/dashboards/coredns.libsonnet
@@ -203,7 +203,7 @@ local singlestat = grafana.singlestat;
             value: 'default',
           },
           hide: 0,
-          label: null,
+          label: 'Data Source',
           name: 'datasource',
           options: [],
           query: 'prometheus',


### PR DESCRIPTION
Hi @povilasv! We're building a linter for mixins & grafana dashboards and this was one of the things that it turned up.  Sorry for the super minor nit!

Signed-off-by: Tom Wilkie <tom@grafana.com>