### PR TITLE
Flip by() to without() to keep possible custom/external labels in alerts

### DIFF
--- a/alerts/coredns.libsonnet
+++ b/alerts/coredns.libsonnet
@@ -18,50 +18,54 @@
               severity: 'critical',
             },
             annotations: {
-              message: 'CoreDNS has disappeared from Prometheus target discovery.',
+              summary: 'CoreDNS has disappeared from Prometheus target discovery.',
+              description: 'CoreDNS has disappeared from Prometheus target discovery.',
             },
           },
           {
             alert: 'CoreDNSLatencyHigh',
             expr: |||
-              histogram_quantile(0.99, sum(rate(coredns_dns_request_duration_seconds_bucket{%(corednsSelector)s}[5m])) by(server, zone, le)) > %(corednsLatencyCriticalSeconds)s
+              histogram_quantile(0.99, sum(rate(coredns_dns_request_duration_seconds_bucket{%(corednsSelector)s}[5m])) without (instance,pod)) > %(corednsLatencyCriticalSeconds)s
             ||| % $._config,
             'for': '10m',
             labels: {
               severity: 'critical',
             },
             annotations: {
-              message: 'CoreDNS has 99th percentile latency of {{ $value }} seconds for server {{ $labels.server }} zone {{ $labels.zone }} .',
+              summary: 'CoreDNS is experiencing high 99th percentile latency.',
+              description: 'CoreDNS has 99th percentile latency of {{ $value }} seconds for server {{ $labels.server }} zone {{ $labels.zone }} .',
             },
           },
           {
             alert: 'CoreDNSErrorsHigh',
             expr: |||
-              sum(rate(coredns_dns_responses_total{%(corednsSelector)s,rcode="SERVFAIL"}[5m]))
+              sum without (pod, instance, server, zone, view, rcode, plugin) (rate(coredns_dns_responses_total{%(corednsSelector)s,rcode="SERVFAIL"}[5m]))
                 /
-              sum(rate(coredns_dns_responses_total{%(corednsSelector)s}[5m])) > 0.03
+              sum without (pod, instance, server, zone, view, rcode, plugin) (rate(coredns_dns_responses_total{%(corednsSelector)s}[5m])) > 0.03
             ||| % $._config,
             'for': '10m',
             labels: {
               severity: 'critical',
             },
             annotations: {
-              message: 'CoreDNS is returning SERVFAIL for {{ $value | humanizePercentage }} of requests.',
+              summary: 'CoreDNS is returning SERVFAIL.',
+              description: 'CoreDNS is returning SERVFAIL for {{ $value | humanizePercentage }} of requests.',
             },
           },
           {
             alert: 'CoreDNSErrorsHigh',
             expr: |||
-              sum(rate(coredns_dns_responses_total{%(corednsSelector)s,rcode="SERVFAIL"}[5m]))
+              sum without (pod, instance, server, zone, view, rcode, plugin) (rate(coredns_dns_responses_total{%(corednsSelector)s,rcode="SERVFAIL"}[5m]))
                 /
-              sum(rate(coredns_dns_responses_total{%(corednsSelector)s}[5m])) > 0.01
+              sum without (pod, instance, server, zone, view, rcode, plugin) (rate(coredns_dns_responses_total{%(corednsSelector)s}[5m])) > 0.01
             ||| % $._config,
             'for': '10m',
             labels: {
               severity: 'warning',
             },
             annotations: {
-              message: 'CoreDNS is returning SERVFAIL for {{ $value | humanizePercentage }} of requests.',
+              summary: 'CoreDNS is returning SERVFAIL.',
+              description: 'CoreDNS is returning SERVFAIL for {{ $value | humanizePercentage }} of requests.',
             },
           },
         ],

--- a/alerts/forward.libsonnet
+++ b/alerts/forward.libsonnet
@@ -11,70 +11,75 @@
           {
             alert: 'CoreDNSForwardLatencyHigh',
             expr: |||
-              histogram_quantile(0.99, sum(rate(coredns_forward_request_duration_seconds_bucket{%(corednsSelector)s}[5m])) by(to, le)) > %(corednsForwardLatencyCriticalSeconds)s
+              histogram_quantile(0.99, sum(rate(coredns_forward_request_duration_seconds_bucket{%(corednsSelector)s}[5m])) without (pod, instance, rcode)) > %(corednsForwardLatencyCriticalSeconds)s
             ||| % $._config,
             'for': '10m',
             labels: {
               severity: 'critical',
             },
             annotations: {
-              message: 'CoreDNS has 99th percentile latency of {{ $value }} seconds forwarding requests to {{ $labels.to }}.',
+              summary: 'CoreDNS is experiencing high latency forwarding requests.',
+              description: 'CoreDNS has 99th percentile latency of {{ $value }} seconds forwarding requests to {{ $labels.to }}.',
             },
           },
           {
             alert: 'CoreDNSForwardErrorsHigh',
             expr: |||
-              sum(rate(coredns_forward_responses_total{%(corednsSelector)s,rcode="SERVFAIL"}[5m]))
+              sum without (pod, instance, rcode) (rate(coredns_forward_responses_total{%(corednsSelector)s,rcode="SERVFAIL"}[5m]))
                 /
-              sum(rate(coredns_forward_responses_total{%(corednsSelector)s}[5m])) > 0.03
+              sum without (pod, instance, rcode) (rate(coredns_forward_responses_total{%(corednsSelector)s}[5m])) > 0.03
             ||| % $._config,
             'for': '10m',
             labels: {
               severity: 'critical',
             },
             annotations: {
-              message: 'CoreDNS is returning SERVFAIL for {{ $value | humanizePercentage }} of forward requests to {{ $labels.to }}.',
+              summary: 'CoreDNS is returning SERVFAIL for forward requests.',
+              description: 'CoreDNS is returning SERVFAIL for {{ $value | humanizePercentage }} of forward requests to {{ $labels.to }}.',
             },
           },
           {
             alert: 'CoreDNSForwardErrorsHigh',
             expr: |||
-              sum(rate(coredns_forward_responses_total{%(corednsSelector)s,rcode="SERVFAIL"}[5m]))
+              sum without (pod, instance, rcode) (rate(coredns_forward_responses_total{%(corednsSelector)s,rcode="SERVFAIL"}[5m]))
                 /
-              sum(rate(coredns_forward_responses_total{%(corednsSelector)s}[5m])) > 0.01
+              sum without (pod, instance, rcode) (rate(coredns_forward_responses_total{%(corednsSelector)s}[5m])) > 0.01
             ||| % $._config,
             'for': '10m',
             labels: {
               severity: 'warning',
             },
             annotations: {
-              message: 'CoreDNS is returning SERVFAIL for {{ $value | humanizePercentage }} of forward requests to {{ $labels.to }}.',
+              summary: 'CoreDNS is returning SERVFAIL for forward requests.',
+              description: 'CoreDNS is returning SERVFAIL for {{ $value | humanizePercentage }} of forward requests to {{ $labels.to }}.',
             },
           },
           {
             alert: 'CoreDNSForwardHealthcheckFailureCount',
             expr: |||
-              sum(rate(coredns_forward_healthcheck_failures_total{%(corednsSelector)s}[5m])) by (to) > 0
+              sum without (pod, instance) (rate(coredns_forward_healthcheck_failures_total{%(corednsSelector)s}[5m])) > 0
             ||| % $._config,
             'for': '10m',
             labels: {
               severity: 'warning',
             },
             annotations: {
-              message: 'CoreDNS health checks have failed to upstream server {{ $labels.to }}.',
+              summary: 'CoreDNS health checks have failed to upstream server.',
+              description: 'CoreDNS health checks have failed to upstream server {{ $labels.to }}.',
             },
           },
           {
             alert: 'CoreDNSForwardHealthcheckBrokenCount',
             expr: |||
-              sum(rate(coredns_forward_healthcheck_broken_total{%(corednsSelector)s}[5m])) > 0
+              sum without (pod, instance) (rate(coredns_forward_healthcheck_broken_total{%(corednsSelector)s}[5m])) > 0
             ||| % $._config,
             'for': '10m',
             labels: {
               severity: 'warning',
             },
             annotations: {
-              message: 'CoreDNS health checks have failed for all upstream servers.',
+              summary: 'CoreDNS health checks have failed for all upstream servers.',
+              description: 'CoreDNS health checks have failed for all upstream servers.',
             },
           },
         ],


### PR DESCRIPTION
Flip by() to without() to keep possible custom/external labels in alerrts for routing/descriptions

Aggregation happens without
metrics built-in labels (https://coredns.io/plugins/metrics/#description) and instance,pod dimentions. If compared side-by-side, aggregation results of by() and without() are identical but without() has all possible custom labels in place.

One more example here: https://promlabs.com/blog/2022/12/11/avoid-these-6-mistakes-when-getting-started-with-prometheus/#mistake-2-aggregating-away-valuable-labels-in-alerting-expressions

Also update message to summary/description according to this  https://monitoring.mixins.dev/#guidelines-for-alert-names-labels-and-annotations